### PR TITLE
Use resource patch

### DIFF
--- a/.github/workflows/update_abstimmungsergebnisse.yml
+++ b/.github/workflows/update_abstimmungsergebnisse.yml
@@ -13,7 +13,7 @@ jobs:
     environment: production
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.7]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update_abstimmungsergebnisse.yml
+++ b/.github/workflows/update_abstimmungsergebnisse.yml
@@ -13,7 +13,7 @@ jobs:
     environment: production
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v3
@@ -39,8 +39,8 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f abstimmungen_seit1933.csv -d politik_abstimmungen_seit1933
-        python automation/upload_resource_to_ckan.py -f abstimmungen_seit1933.parquet -d politik_abstimmungen_seit1933
+        python automation/upload_resource_to_ckan_with_patch.py -f abstimmungen_seit1933.csv -d politik_abstimmungen_seit1933
+        python automation/upload_resource_to_ckan_with_patch.py -f abstimmungen_seit1933.parquet -d politik_abstimmungen_seit1933
 
     - name: Update CKAN metadata
       env:

--- a/.github/workflows/update_abstimmungsparolen.yml
+++ b/.github/workflows/update_abstimmungsparolen.yml
@@ -68,7 +68,7 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f automation/abstimmungsparolen/abstimmungsparolen.csv -d politik_abstimmungsparolen_gemeindeabstimmung_seit2012
+        python automation/upload_resource_to_ckan_with_patch.py -f automation/abstimmungsparolen/abstimmungsparolen.csv -d politik_abstimmungsparolen_gemeindeabstimmung_seit2012
 
     - name: Update CKAN metadata
       if: ${{ steps.changes.outputs.changed == 1 || github.event.inputs.force_update != 'false' }}

--- a/.github/workflows/update_ckan_metadata.yml
+++ b/.github/workflows/update_ckan_metadata.yml
@@ -38,7 +38,7 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f ogd_katalog_inventar.csv -d prd_ssz_ogd_katalog_inventar
+        python automation/upload_resource_to_ckan_with_patch.py -f ogd_katalog_inventar.csv -d prd_ssz_ogd_katalog_inventar
 
     - name: Update CKAN metadata
       env:

--- a/.github/workflows/update_dummy_data.yml
+++ b/.github/workflows/update_dummy_data.yml
@@ -10,7 +10,7 @@ jobs:
     environment: integration
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/update_dummy_data.yml
+++ b/.github/workflows/update_dummy_data.yml
@@ -33,8 +33,8 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f dummy_resource.csv -d dummy_dataset
-        python automation/upload_resource_to_ckan.py -f dummy_resource.parquet -d dummy_dataset
+        python automation/upload_resource_to_ckan_with_patch.py -f dummy_resource.csv -d dummy_dataset
+        python automation/upload_resource_to_ckan_with_patch.py -f dummy_resource.parquet -d dummy_dataset
 
 #    - name: Update CKAN metadata
 #      env:

--- a/.github/workflows/update_hystreet_fussgaengerfrequenzen.yml
+++ b/.github/workflows/update_hystreet_fussgaengerfrequenzen.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -40,8 +41,8 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f hystreet_fussgaengerfrequenzen_seit2021.csv -d hystreet_fussgaengerfrequenzen
-        python automation/upload_resource_to_ckan.py -f hystreet_locations.json -d hystreet_fussgaengerfrequenzen
+        python automation/upload_resource_to_ckan_with_patch.py -f hystreet_fussgaengerfrequenzen_seit2021.csv -d hystreet_fussgaengerfrequenzen
+        python automation/upload_resource_to_ckan_with_patch.py -f hystreet_locations.json -d hystreet_fussgaengerfrequenzen
 
     - name: Update CKAN metadata
       env:

--- a/.github/workflows/update_mrz_himmelheber.yml
+++ b/.github/workflows/update_mrz_himmelheber.yml
@@ -38,8 +38,8 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f automation/mrz_himmelheber/mrz_himmelheber_fotos.csv -d mrz_himmelheber_fotos
-        python automation/upload_resource_to_ckan.py -f automation/mrz_himmelheber/mrz_himmelheber_objekte.csv -d mrz_himmelheber_objekte
+        python automation/upload_resource_to_ckan_with_patch.py -f automation/mrz_himmelheber/mrz_himmelheber_fotos.csv -d mrz_himmelheber_fotos
+        python automation/upload_resource_to_ckan_with_patch.py -f automation/mrz_himmelheber/mrz_himmelheber_objekte.csv -d mrz_himmelheber_objekte
 
     - name: Update CKAN metadata
       env:

--- a/.github/workflows/update_mrz_patolu.yml
+++ b/.github/workflows/update_mrz_patolu.yml
@@ -65,7 +65,7 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f automation/mrz_patolu/mrz_patolu.csv -d mrz_patolu
+        python automation/upload_resource_to_ckan_with_patch.py -f automation/mrz_patolu/mrz_patolu.csv -d mrz_patolu
 
     - name: Update CKAN metadata
       if: ${{ steps.changes.outputs.changed == 1 || github.event.inputs.force_update != 'false' }}

--- a/.github/workflows/update_sar_geschaeftsberichte.yml
+++ b/.github/workflows/update_sar_geschaeftsberichte.yml
@@ -37,7 +37,7 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f sar_geschaeftsberichte.csv -d sar_geschaeftsberichte
+        python automation/upload_resource_to_ckan_with_patch.py -f sar_geschaeftsberichte.csv -d sar_geschaeftsberichte
 
     - name: Update CKAN metadata
       env:

--- a/.github/workflows/update_schulferien.yml
+++ b/.github/workflows/update_schulferien.yml
@@ -65,7 +65,7 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py -f automation/schulferien/schulferien.csv -d ssd_schulferien
+        python automation/upload_resource_to_ckan_with_patch.py -f automation/schulferien/schulferien.csv -d ssd_schulferien
 
     - name: Update CKAN metadata
       if: ${{ steps.changes.outputs.changed == 1 || github.event.inputs.force_update != 'false' }}

--- a/.github/workflows/update_stimmbeteiligung.yml
+++ b/.github/workflows/update_stimmbeteiligung.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -62,7 +63,7 @@ jobs:
         CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
-        python automation/upload_resource_to_ckan.py --no-verify -f automation/stimmbeteiligung/stimmbeteiligung.csv -d politik_stimmbeteiligung-vor-urnengangen
+        python automation/upload_resource_to_ckan_with_patch.py --no-verify -f automation/stimmbeteiligung/stimmbeteiligung.csv -d politik_stimmbeteiligung-vor-urnengangen
 
     - name: Update CKAN metadata
       if: ${{ steps.changes.outputs.changed == 1 || github.event.inputs.force_update != 'false' }}

--- a/.github/workflows/update_wapo_wetterstationen.yml
+++ b/.github/workflows/update_wapo_wetterstationen.yml
@@ -41,8 +41,8 @@ jobs:
       run: |
         my_path=$(ls automation/wapo_wetterstationen/messwerte_mythenquai_*.csv | head -n1)
         tb_path=$(ls automation/wapo_wetterstationen/messwerte_tiefenbrunnen_*.csv | head -n1)
-        python automation/upload_resource_to_ckan.py -f $my_path -d sid_wapo_wetterstationen
-        python automation/upload_resource_to_ckan.py -f $tb_path -d sid_wapo_wetterstationen
+        python automation/upload_resource_to_ckan_with_patch.py -f $my_path -d sid_wapo_wetterstationen
+        python automation/upload_resource_to_ckan_with_patch.py -f $tb_path -d sid_wapo_wetterstationen
 #        python automation/upload_resource_to_ckan_with_patch.py -f automation/wapo_wetterstationen/messwerte_mythenquai_seit2007-heute.parquet -d sid_wapo_wetterstationen
 #        python automation/upload_resource_to_ckan_with_patch.py -f automation/wapo_wetterstationen/messwerte_tiefenbrunnen_seit2007-heute.parquet -d sid_wapo_wetterstationen
 

--- a/.github/workflows/update_wapo_wetterstationen.yml
+++ b/.github/workflows/update_wapo_wetterstationen.yml
@@ -20,6 +20,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/automation/dummy_data/get_dummy_data.py
+++ b/automation/dummy_data/get_dummy_data.py
@@ -38,7 +38,7 @@ arguments = docopt(__doc__, version='Fetch CSV from CKAN API 1.0')
 
 # Getting dummy_resource.csv vom INT (dataset: dummy_dataset)
 url = "https://data.integ.stadt-zuerich.ch/dataset/dummy_dataset/download/dummy_resource.csv"
-res_pd = pd.read_csv(url)
+res_pd = pd.read_csv(url, storage_options={'verify': False})
 
 # saving as csv
 print("Saving csv")

--- a/automation/dummy_data/get_dummy_data.py
+++ b/automation/dummy_data/get_dummy_data.py
@@ -16,12 +16,8 @@ Options:
 """
 
 import pandas as pd
-import os
 from docopt import docopt
 from dotenv import load_dotenv, find_dotenv
-import pyarrow
-import fastparquet
-from ckanapi import RemoteCKAN, NotFound
 import ssl  
 ssl._create_default_https_context = ssl._create_unverified_context
 

--- a/automation/dummy_data/get_dummy_data.py
+++ b/automation/dummy_data/get_dummy_data.py
@@ -22,6 +22,8 @@ from dotenv import load_dotenv, find_dotenv
 import pyarrow
 import fastparquet
 from ckanapi import RemoteCKAN, NotFound
+import ssl  
+ssl._create_default_https_context = ssl._create_unverified_context
 
 # Load environment variables from a .env file in the project directory
 load_dotenv(find_dotenv())
@@ -38,7 +40,7 @@ arguments = docopt(__doc__, version='Fetch CSV from CKAN API 1.0')
 
 # Getting dummy_resource.csv vom INT (dataset: dummy_dataset)
 url = "https://data.integ.stadt-zuerich.ch/dataset/dummy_dataset/download/dummy_resource.csv"
-res_pd = pd.read_csv(url, storage_options={'verify': False})
+res_pd = pd.read_csv(url)
 
 # saving as csv
 print("Saving csv")


### PR DESCRIPTION
Im Moment wird beim allgemeinen Upload zu CKAN (upload_resource_to_ckan.py) die Funktion `resource_update` verwendet. Die ist aber wohl nicht so verlässlichen (siehe [CKAN Doku](https://docs.ckan.org/en/2.9/api/#ckan.logic.action.update.resource_update)). Man soll doch besser diese [Funktion](https://docs.ckan.org/en/2.9/api/#ckan.logic.action.patch.resource_patch) verwenden. Lorenz hat das schonmal vorbereitet in der Datei upload_resource_to_ckan_with_patch.py.
Hier werden die noch fehlenden Workflows entsprechend nachgezogen.