### PR TITLE
Collect harvester info in a single table

### DIFF
--- a/automation/notify_datasets/notify.py
+++ b/automation/notify_datasets/notify.py
@@ -1,21 +1,18 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
-import re
 import datetime
 import traceback
 import pytz
 import math
 import requests
+import pandas as pd
 from ckanapi import RemoteCKAN, NotFound
 import teams_webhook
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 
-# TELEGRAM_TOKEN bekommt man beim erstellen eines neuen Bots
-# Neuer Bot => Chatten mit BotFather auf Telegram
-TELEGRAM_TOKEN = os.getenv('TELEGRAM_TOKEN')
-TELEGRAM_CHAT_ID = os.getenv('TELEGRAM_TO')
+
 MSTEAMS_WEBHOOK = os.getenv('MSTEAMS_WEBHOOK')
 
 
@@ -46,6 +43,18 @@ def send_teams_message(webhook, message, title=None):
     myTeamsMessage.text(message)
     myTeamsMessage.send()
 
+def to_markdown(df):
+    """
+    Format pandas df as markdown
+    """
+    # Create a new DataFrame with just the markdown title strings
+    df2 = pd.DataFrame([['---',]*len(df.columns)], columns=df.columns)
+
+    #Create a new concatenated DataFrame
+    df3 = pd.concat([df2, df])
+    # return | separatet csv aka markdown
+    return df3.to_csv(sep='|', index=False)
+
 
 try:
     BASE_URL = os.getenv('CKAN_BASE_URL')
@@ -54,15 +63,24 @@ try:
 
     # get list + status of all harvesters
     harvesters = ckan.call_action('harvest_source_list')
-    for harvester in harvesters:
+
+    data_dict = {} # empty dict to gather info from distinct harvester runs
+    for harvester in harvesters:        
         try:
             if not harvester['active']:
                 continue
             try:
                 source_info = ckan.call_action('harvest_source_show', {'id': harvester['id']})
+
                 last_job_stats = source_info['status']['last_job']['stats']
+                print("name:",source_info['name'])
+                print("last_job_stats",last_job_stats)
+                print(f"https://ckan-prod.zurich.datopian.com/harvest/{source_info['name']}/job/{source_info['status']['last_job']['id']}")
             except (NotFound, TypeError):
+                print("there is no last_job or harvester NotFound")
                 continue # there is no "last_job" or harvester NotFound
+            
+            # gather info for last run and format dates
             name = source_info['name']
             job_id = source_info['status']['last_job']['id']
 
@@ -86,8 +104,14 @@ try:
                 elapsed_time = end - start
                 minutes, seconds = divmod(elapsed_time.total_seconds(), 60)
                 duration = f'{int(minutes):02}:{math.floor(seconds):02} min'
+
+                created_start = start.strftime('%Y-%m-%dT%H:%M:%SZ')
+                created_end = end.strftime('%Y-%m-%dT23:59:59Z') # always use end of day as end
             else:
                 duration = 'unbekannt'
+                # dummy text for url if time not available
+                created_start = "XXX"
+                created_end = "XXX"
             
             # skip if last harvest job is older than 24h
             # but raise as error if there is no end time
@@ -100,44 +124,41 @@ try:
                     runs_too_long = True
                     duration = ">=24h!"
                 elif since_last_run > (24*60*60) and end:
+                    print("skip because too old")
                     continue
 
+            # set status
             if last_job_stats['deleted'] > 0 or last_job_stats['errored'] > 0:
                 status = '🔴'
             elif last_job_stats['added'] > 0 or runs_too_long:
                 status = '🟡'
             else:
                 status = '🟢'
-                
-            
-            # generate links for new/updated datasets
-            text = f"<b><a href='https://ckan-prod.zurich.datopian.com/harvest/{name}/job/{job_id}'>{source_info['title']}</a></b>"
-            text += f'\n{status} {start_datetime}'
-            text += f'\n🏁 {end_datetime}'
-            text += f'\n⏱ {duration}'
-            if start and end:
-                created_start = start.strftime('%Y-%m-%dT%H:%M:%SZ')
-                created_end = end.strftime('%Y-%m-%dT23:59:59Z') # always use end of day as end
-                new_url = f"https://data.stadt-zuerich.ch/dataset?q=harvest_source_id%3A{harvester['id']}+AND+metadata_created%3A%5B{created_start}+TO+{created_end}%5D"
-                new_link = f"<b><a href='{new_url}'>Neue Datensätze</a></b>"
-                update_url = f"https://data.stadt-zuerich.ch/dataset?q=harvest_source_id%3A{harvester['id']}+AND+metadata_modified%3A%5B{created_start}+TO+{created_end}%5D"
-                update_link = f"<b><a href='{update_url}'>Aktualisierte Datensätze</a></b>"
-                text += f"\n\n🔍 {new_link}\n🔍 {update_link}"
 
-            text += f"\n\n<b>Neu</b>: {last_job_stats['added']}"
-            text += f"\n<b>Aktualisiert</b>: {last_job_stats['updated']}"
-            text += f"\n<b>Gelöscht</b>: {last_job_stats['deleted']}"
-            text += f"\n<b>Fehler</b>: {last_job_stats['errored']}"
-
-            try:
-                # send_telegram_message(TELEGRAM_TOKEN, TELEGRAM_CHAT_ID, text)
-                send_teams_message(MSTEAMS_WEBHOOK, text, title=None)
-            except requests.HTTPError as e:
-                print(f"Error when sending message to telegram/teams for harvester {harvester}: {e}", file=sys.stderr)
-                raise
+            # add harvester run info to dict
+            data_dict[name] = {
+                'harvester titel': f'[{source_info["title"]}](https://ckan-prod.zurich.datopian.com/harvest/{name}/job/{job_id})',
+                'status': status,
+                'start': start_datetime,
+                'ende': end_datetime,
+                'dauer': duration,
+                # 'harvester_url': f'https://ckan-prod.zurich.datopian.com/harvest/{name}/job/{job_id}',
+                'anzahl neu': last_job_stats['added'],
+                'url neue': f"[zeige neue](https://data.stadt-zuerich.ch/dataset?q=harvest_source_id%3A{harvester['id']}+AND+metadata_created%3A%5B{created_start}+TO+{created_end}%5D)",
+                'anzahl aktualisiert': last_job_stats['updated'],
+                'url aktualisierte': f"[zeige aktual.](https://data.stadt-zuerich.ch/dataset?q=harvest_source_id%3A{harvester['id']}+AND+metadata_modified%3A%5B{created_start}+TO+{created_end}%5D)",
+                'anzahl gelöscht': last_job_stats['deleted'],
+                'anzahl fehler': last_job_stats['errored'],
+            }
         except Exception as e:
             print(f"Failed for harvester {harvester} with error: {e}", file=sys.stderr)
             raise
+
+    # make df from dict and send to teams
+    df = pd.DataFrame(data_dict).T
+    print(df)
+    send_teams_message(MSTEAMS_WEBHOOK, to_markdown(df), title="Harvester Info letzter run")
+
 except Exception as e:
     print(f"Error: {e}", file=sys.stderr)
     print(traceback.format_exc(), file=sys.stderr)


### PR DESCRIPTION
Previously, a single teams message was sent for each harvester. Now everything is collected in one table and there is only one message. This is cleaner.