### PR TITLE
Hardbruecke quickfix

### DIFF
--- a/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
+++ b/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
@@ -9,7 +9,7 @@ jobs:
   update_data_py:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    environment: integration
+    environment: production
     strategy:
       matrix:
         python-version: [3.12]
@@ -38,7 +38,7 @@ jobs:
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
         year=$(date +'%Y')
-        # python automation/upload_resource_to_ckan_with_patch.py -f automation/vbz_frequenzen_hardbruecke/frequenzen_hardbruecke_${year}.csv -d vbz_frequenzen_hardbruecke
+        python automation/upload_resource_to_ckan_with_patch.py -f automation/vbz_frequenzen_hardbruecke/frequenzen_hardbruecke_${year}.csv -d vbz_frequenzen_hardbruecke
         python automation/upload_resource_to_ckan_with_patch.py -f automation/vbz_frequenzen_hardbruecke/frequenzen_hardbruecke_${year}.parquet -d vbz_frequenzen_hardbruecke
 
     - name: Update CKAN metadata

--- a/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
+++ b/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
@@ -9,7 +9,7 @@ jobs:
   update_data_py:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    environment: production
+    environment: integration
     strategy:
       matrix:
         python-version: [3.12]

--- a/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
+++ b/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
@@ -38,7 +38,7 @@ jobs:
         SSL_VERIFY: ${{ secrets.SSL_VERIFY }}
       run: |
         year=$(date +'%Y')
-        python automation/upload_resource_to_ckan_with_patch.py -f automation/vbz_frequenzen_hardbruecke/frequenzen_hardbruecke_${year}.csv -d vbz_frequenzen_hardbruecke
+        # python automation/upload_resource_to_ckan_with_patch.py -f automation/vbz_frequenzen_hardbruecke/frequenzen_hardbruecke_${year}.csv -d vbz_frequenzen_hardbruecke
         python automation/upload_resource_to_ckan_with_patch.py -f automation/vbz_frequenzen_hardbruecke/frequenzen_hardbruecke_${year}.parquet -d vbz_frequenzen_hardbruecke
 
     - name: Update CKAN metadata

--- a/automation/vbz_frequenzen_hardbruecke/fetch_from_api.py
+++ b/automation/vbz_frequenzen_hardbruecke/fetch_from_api.py
@@ -67,7 +67,8 @@ try:
             final_df = pd.concat([final_df, df], ignore_index=True)
         count = pd.concat([count, final_df], ignore_index=True)
         locations = pd.concat([locations, pd.DataFrame.from_dict(location_json, orient='columns')], ignore_index=True)
-        locations["IsIncludedForParent"] = locations["IsIncludedForParent"].astype(bool)  # Explicitly cast to bool dtype to avoid the warning about future version
+        # the field IsIncludedForParent is no longer in the data (and is not used in this skript)
+        # locations["IsIncludedForParent"] = locations["IsIncludedForParent"].astype(bool)  # Explicitly cast to bool dtype to avoid the warning about future version
 
     df_count = pd.DataFrame.from_dict(count)
 


### PR DESCRIPTION
Workflows crashing since 2025-02-19 18:XX because field `IsIncludedForParent` is not present anymore. The code is only type casting that field to bool. Later it is not used anymore -> commented out that part.
Tested on Integ:
https://ckan-staging.zurich.datopian.com/dataset/vbz_frequenzen_hardbruecke/resource/47bba784-d19f-48c2-95b8-eabefc534cb3
Works again (numbers are plausible). 
Still in contact with VBZ why the field was excluded and if it is a problem.