### PR TITLE
Uv for high freq workflows

### DIFF
--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -10,25 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
-    strategy:
-      matrix:
-        python-version: [3.12]
 
     steps:
     # checkout repos
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-   # Setup Python
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      
+    - name: "Set up Python"
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
+        python-version: 3.12
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r automation/automation-requirements.txt
+    - name: Install requirements
+      run: uv pip install -r automation/automation-requirements.txt
+      env:
+        UV_SYSTEM_PYTHON: 1
     
     # run the scripts
     - name: Tag CKAN datasets

--- a/.github/workflows/update_hystreet_fussgaengerfrequenzen.yml
+++ b/.github/workflows/update_hystreet_fussgaengerfrequenzen.yml
@@ -10,21 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: production
-    strategy:
-      matrix:
-        python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      
+    - name: "Set up Python"
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r automation/automation-requirements.txt
+        python-version: 3.12
+
+    - name: Install requirements
+      run: uv pip install -r automation/automation-requirements.txt
+      env:
+        UV_SYSTEM_PYTHON: 1
         
     - name: Prepare data
       env:

--- a/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
+++ b/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
@@ -10,20 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: production
-    strategy:
-      matrix:
-        python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      
+    - name: "Set up Python"
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r automation/automation-requirements.txt
+        python-version: 3.12
+
+    - name: Install requirements
+      run: uv pip install -r automation/automation-requirements.txt
+      env:
+        UV_SYSTEM_PYTHON: 1
         
     - name: Prepare data
       env:

--- a/.github/workflows/update_wapo_wetterstationen.yml
+++ b/.github/workflows/update_wapo_wetterstationen.yml
@@ -10,21 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
-    strategy:
-      matrix:
-        python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+      
+    - name: "Set up Python"
+      uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r automation/automation-requirements.txt
+        python-version: 3.12
+
+    - name: Install requirements
+      run: uv pip install -r automation/automation-requirements.txt
+      env:
+        UV_SYSTEM_PYTHON: 1
         
     - name: Prepare data
       env:


### PR DESCRIPTION
Use uv instead of pip for workflows.
Some of the workflows run very often (hourly or more). Each time depencies are installed via pip. Now they use uv which is significantly faster.
All involved workflows were tested seperately and still work.