### PR TITLE
start abstimmungsergebnisse 1h earlier

### DIFF
--- a/.github/workflows/update_abstimmungsergebnisse.yml
+++ b/.github/workflows/update_abstimmungsergebnisse.yml
@@ -2,7 +2,7 @@ name: Update Abstimmungsergebnisse
 
 on:
   schedule:
-    - cron: '0 6 * * 1' # jeden Montag um 8 Uhr
+    - cron: '0 5 * * 1' # jeden Montag um 7 Uhr
   workflow_dispatch:
 
 


### PR DESCRIPTION
Auf diesem Datensatz beruht eine Shiny App
https://www.stadt-zuerich.ch/de/politik-und-verwaltung/statistik-und-daten/daten/politik-und-verwaltung/politik/abstimmungen.html

Diese App wird um 8 Uhr aktualisiert. Damit es keine Konflikte bei der Aktualisierung gibt, wird der Workflow eine Stunde nach vorne verschoben. Das ist mit Ale so abgestimmt.