### PR TITLE
Update Actions because of nodejs deprecation

### DIFF
--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Link Checker for Repository
         id: lychee_repo

--- a/.github/workflows/notify_datasets.yml
+++ b/.github/workflows/notify_datasets.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'

--- a/.github/workflows/reorder-resources.yml
+++ b/.github/workflows/reorder-resources.yml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
     # checkout repos
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Checkout ckan-admin-scripts repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
       with:
         repository: metaodi/ckan-admin-scripts
         path: ckan-admin-scripts
 
    # Setup Python
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/tagger.yml
+++ b/.github/workflows/tagger.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
     # checkout repos
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_abstimmungsergebnisse.yml
+++ b/.github/workflows/update_abstimmungsergebnisse.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_abstimmungsparolen.yml
+++ b/.github/workflows/update_abstimmungsparolen.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
       run: automation/abstimmungsparolen/run_scraper.sh
     
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: abstimmungsparolen
         path: automation/abstimmungsparolen/abstimmungsparolen.csv

--- a/.github/workflows/update_badi_aktuell.yml
+++ b/.github/workflows/update_badi_aktuell.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
       uses: actions/setup-python@v6

--- a/.github/workflows/update_badi_aktuell.yml
+++ b/.github/workflows/update_badi_aktuell.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8
+      uses: astral-sh/setup-uv@v5
       
     - name: "Set up Python"
       uses: actions/setup-python@v6

--- a/.github/workflows/update_badi_aktuell.yml
+++ b/.github/workflows/update_badi_aktuell.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv
       
     - name: "Set up Python"
       uses: actions/setup-python@v6

--- a/.github/workflows/update_badi_aktuell.yml
+++ b/.github/workflows/update_badi_aktuell.yml
@@ -13,13 +13,13 @@ jobs:
     environment: integration
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_badi_besuch.yml
+++ b/.github/workflows/update_badi_besuch.yml
@@ -13,13 +13,13 @@ jobs:
     environment: integration
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_ckan_metadata.yml
+++ b/.github/workflows/update_ckan_metadata.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_combine_csv_to_parquet.yml
+++ b/.github/workflows/update_combine_csv_to_parquet.yml
@@ -13,13 +13,13 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/.github/workflows/update_dib_wvz_brunnenfotos.yml
+++ b/.github/workflows/update_dib_wvz_brunnenfotos.yml
@@ -14,13 +14,13 @@ jobs:
     environment: production
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_download_statistics.yml
+++ b/.github/workflows/update_download_statistics.yml
@@ -21,13 +21,13 @@ jobs:
     environment: production
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_dummy_data.yml
+++ b/.github/workflows/update_dummy_data.yml
@@ -13,9 +13,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_hystreet_fussgaengerfrequenzen.yml
+++ b/.github/workflows/update_hystreet_fussgaengerfrequenzen.yml
@@ -12,13 +12,13 @@ jobs:
     environment: production
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_immo_ginto_zugaenglichkeit.yml
+++ b/.github/workflows/update_immo_ginto_zugaenglichkeit.yml
@@ -13,13 +13,13 @@ jobs:
     environment: integration
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_mrz_himmelheber.yml
+++ b/.github/workflows/update_mrz_himmelheber.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_mrz_kamerun_objekte.yml
+++ b/.github/workflows/update_mrz_kamerun_objekte.yml
@@ -12,13 +12,13 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/.github/workflows/update_mrz_patolu.yml
+++ b/.github/workflows/update_mrz_patolu.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_sar_geschaeftsberichte.yml
+++ b/.github/workflows/update_sar_geschaeftsberichte.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_schulferien.yml
+++ b/.github/workflows/update_schulferien.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_sonnenscheindauer.yml
+++ b/.github/workflows/update_sonnenscheindauer.yml
@@ -15,9 +15,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/update_stadtratsbeschluesse.yml
+++ b/.github/workflows/update_stadtratsbeschluesse.yml
@@ -12,13 +12,13 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.1.0
         
       - name: "Set up Python"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
 

--- a/.github/workflows/update_stimmbeteiligung.yml
+++ b/.github/workflows/update_stimmbeteiligung.yml
@@ -20,9 +20,9 @@ jobs:
         python-version: [3.12]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -75,7 +75,7 @@ jobs:
         python automation/xls_to_meta_xml.py -f automation/stimmbeteiligung/Meta_Stimmbeteiligung.xlsx --outfile automation/stimmbeteiligung/meta.xml --tag github
         python automation/update_metadata.py --no-verify -d politik_stimmbeteiligung-vor-urnengangen -f automation/stimmbeteiligung/meta.xml
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ steps.changes.outputs.changed == '1' || github.event.inputs.force_update == 'true' }}
       with:
         name: meta.xml

--- a/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
+++ b/.github/workflows/update_vbz_frequenzen_hardbruecke.yml
@@ -12,13 +12,13 @@ jobs:
     environment: production
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 

--- a/.github/workflows/update_wapo_wetterstationen.yml
+++ b/.github/workflows/update_wapo_wetterstationen.yml
@@ -12,13 +12,13 @@ jobs:
     environment: production
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v8.1.0
       
     - name: "Set up Python"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.12
 


### PR DESCRIPTION
Most workflows are showing deprecation infos:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
<img width="1497" height="122" alt="image" src="https://github.com/user-attachments/assets/67ce794a-894c-45c5-90af-f7173cea5375" />

Update the actions to current versions.
