### PR TITLE
replace doctops

### DIFF
--- a/automation/automation-requirements.txt
+++ b/automation/automation-requirements.txt
@@ -1,7 +1,7 @@
 python-dotenv
 requests
 ckanapi
-docopts
+docopt-ng
 pytz
 sruthi
 beautifulsoup4


### PR DESCRIPTION
The docopt library is no longer supported and throws warning in our current python version:
<img width="1060" height="227" alt="image" src="https://github.com/user-attachments/assets/ea970461-d8c3-450f-9dd1-a2a75caf9d62" />
[`docopt-ng`](https://pypi.org/project/docopt-ng/) is a stand-in replacement. 