### PR TITLE
bugfix because of Kreis decimals

### DIFF
--- a/.github/workflows/update_dib_wvz_brunnenfotos.yml
+++ b/.github/workflows/update_dib_wvz_brunnenfotos.yml
@@ -11,7 +11,7 @@ jobs:
   update_data_py:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    environment: integration
+    environment: production
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/update_dib_wvz_brunnenfotos.yml
+++ b/.github/workflows/update_dib_wvz_brunnenfotos.yml
@@ -11,7 +11,7 @@ jobs:
   update_data_py:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    environment: production
+    environment: integration
 
     steps:
     - uses: actions/checkout@v6

--- a/automation/dib_wvz_brunnenfotos/brunnen_image_scraper.py
+++ b/automation/dib_wvz_brunnenfotos/brunnen_image_scraper.py
@@ -77,7 +77,7 @@ def build_brunnen_webseiten(df: pd.DataFrame) -> pd.DataFrame:
 
     df["brunnen_webseite"] = (
         BRUNNEN_URL_PREFIX
-        + df["stadtkreis"].astype(str)
+        + df["stadtkreis"].astype("Int64").astype(str)
         + "/"
         + df["brunnennummer"].str.replace(".", "_", regex=False)
     )


### PR DESCRIPTION
Column `stadtkreis` in Geodata comes as float. Casting to string for URL results in decimals, which lead to wrong URLs:

<img width="1339" height="425" alt="image" src="https://github.com/user-attachments/assets/5e50d790-8aed-4712-959e-66a8f2225849" />

Fix by casting to int before string.