### PR TITLE
use lindas for getting parole dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ env
 .env
 .idea
 __pycache__/
+.claude

--- a/automation/abstimmungsparolen/README.md
+++ b/automation/abstimmungsparolen/README.md
@@ -9,7 +9,7 @@ Abstimmungsparolen der Parteien im Gemeinderat
 |**Datensatz INT:**|[Stimmbeteiligung in Prozent vor Urnengängen (data.integ.stadt-zuerich.ch)](https://data.integ.stadt-zuerich.ch/dataset/politik_stimmbeteiligung-vor-urnengangen)|
 |**Datensatz PROD:**|[Stimmbeteiligung in Prozent vor Urnengängen (data.stadt-zuerich.ch)](https://data.stadt-zuerich.ch/dataset/politik_stimmbeteiligung-vor-urnengangen)|
 
-Die Daten werden von der [Parolen-Schnittstelle vom Statistischen Amt des Kantons Zürich](https://app.statistik.zh.ch/wahlen_abstimmungen/prod/Actual) bezogen basierend auf den [Abstimmungsterminen von der Bundeskanzlei](https://www.bk.admin.ch/ch/d/pore/va/vab_1_3_3_1.html).
+Die Daten werden von der [Parolen-Schnittstelle vom Statistischen Amt des Kantons Zürich](https://app.statistik.zh.ch/wahlen_abstimmungen/prod/Actual) bezogen basierend auf den [Abstimmungsterminen von der Bundeskanzlei](https://www.bk.admin.ch/de/blanko-abstimmungstermine) (bezogen via [LINDAS SPARQL-Endpoint](https://cached.lindas.admin.ch/query), Cube [BK-0003](https://politics.ld.admin.ch/political-rights/popular-vote/voting_dates/1)).
 
 Die Skripte werden alle in [`run_scraper.sh`](https://github.com/opendatazurich/opendatazurich.github.io/blob/master/automation/abstimmungsparolen/run_scraper.sh) und schlussendlich das erstellte CSV im Repository und in CKAN hochgeladen.
 

--- a/automation/abstimmungsparolen/scraper.py
+++ b/automation/abstimmungsparolen/scraper.py
@@ -9,6 +9,8 @@ import sys
 import os
 import traceback
 
+from vote_dates import get_next_scheduled_vote
+
 
 __location__ = os.path.realpath(
     os.path.join(
@@ -23,14 +25,6 @@ def get_json(url):
     r = session.get(url)
     r.raise_for_status()
     return r.json()
-
-
-def get_vote_dates():
-    abst_dates = pd.read_html('https://www.bk.admin.ch/ch/d/pore/va/vab_1_3_3_1.html')[0]
-    abst_df = abst_dates.melt(id_vars=["Jahr"], value_vars=["1. Quartal", "2. Quartal", "3. Quartal", "4. Quartal"], var_name="Quartal")
-    abst_df = abst_df.dropna()
-    abst_df = abst_df.sort_values(by=['Jahr', 'Quartal']).reset_index(drop=True)
-    return abst_df.to_dict('records')
 
 
 def insert_or_update(parole, conn):
@@ -89,16 +83,17 @@ try:
     DATABASE_NAME = os.path.join(__location__, 'data.sqlite')
     conn = sqlite3.connect(DATABASE_NAME)
 
-    # get vote dates
-    vote_dates = get_vote_dates()
-    next_vote = next(a for a in vote_dates if not a['value'].startswith('N'))
-    m = re.match(r"(?P<day>\d{2}).(?P<month>\d{2}).(?P<year>\d{4})", next_vote['value'])
-    datum = f"{m['year']}-{m['month']}-{m['day']}"
+    # get next vote date (via LINDAS)
+    next_vote = get_next_scheduled_vote()
+    if next_vote is None:
+        print("No upcoming scheduled vote found", file=sys.stderr)
+        sys.exit(0)
+    datum = next_vote.isoformat()
 
     # get paroles of current votes
     geolevel = 3
     bfsnr = 261
-    vorlage_url = f"https://app.statistik.zh.ch/wahlen_abstimmungen/data_prod/geschaefte/{geolevel}_{bfsnr}_{m['year']}{m['month']}{m['day']}/Vorlagen.json"
+    vorlage_url = f"https://app.statistik.zh.ch/wahlen_abstimmungen/data_prod/geschaefte/{geolevel}_{bfsnr}_{next_vote:%Y%m%d}/Vorlagen.json"
     
     r = session.get(vorlage_url)
     if r.status_code != requests.codes.ok:

--- a/automation/abstimmungsparolen/vote_dates.py
+++ b/automation/abstimmungsparolen/vote_dates.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""Eidgenössische Abstimmungstermine via LINDAS SPARQL.
+
+Datenquelle: BK-0003 "Abstimmungstermine" der Bundeskanzlei,
+publiziert als Linked-Data-Cube auf LINDAS.
+
+Cube IRI:   https://politics.ld.admin.ch/political-rights/popular-vote/voting_dates/1
+Endpoint:   https://cached.lindas.admin.ch/query
+Webansicht: https://www.bk.admin.ch/de/blanko-abstimmungstermine
+"""
+
+from datetime import date
+import requests
+
+
+SPARQL_ENDPOINT = "https://cached.lindas.admin.ch/query"
+
+# Termintypen, an denen tatsächlich eine eidg. Volksabstimmung
+# stattfindet (im Gegensatz zu reservierten Blankoterminen,
+# ungenutzten Reservedaten oder Nationalratswahlen).
+SCHEDULED_TYPES = frozenset({"festgelegt", "genutzt"})
+
+_QUERY = """
+PREFIX cube: <https://cube.link/>
+PREFIX vd:   <https://politics.ld.admin.ch/political-rights/popular-vote/voting_dates/>
+SELECT ?datum ?typ WHERE {
+  <https://politics.ld.admin.ch/political-rights/popular-vote/voting_dates/1>
+    cube:observationSet/cube:observation ?o .
+  ?o vd:date ?datum ;
+     vd:typ  ?typIri .
+  BIND(REPLACE(STR(?typIri), ".*/", "") AS ?typ)
+}
+ORDER BY ?datum
+"""
+
+
+def fetch_vote_dates():
+    """Alle bekannten Abstimmungstermine als Liste (date, typ)."""
+    r = requests.get(
+        SPARQL_ENDPOINT,
+        params={"query": _QUERY},
+        headers={"Accept": "application/sparql-results+json"},
+    )
+    r.raise_for_status()
+    return [
+        (date.fromisoformat(b["datum"]["value"]), b["typ"]["value"])
+        for b in r.json()["results"]["bindings"]
+    ]
+
+
+def get_next_scheduled_vote(today=None):
+    """Datum der nächsten festgelegten eidg. Volksabstimmung oder None."""
+    today = today or date.today()
+    for datum, typ in fetch_vote_dates():
+        if datum >= today and typ in SCHEDULED_TYPES:
+            return datum
+    return None
+
+
+if __name__ == "__main__":
+    print(get_next_scheduled_vote())


### PR DESCRIPTION
To display the paroles, you first need to retrieve the date of the next vote. Until now, this had to be scraped from: 
[https://www.bk.admin.ch/ch/d/pore/va/vab_1_3_3_1.html](https://www.bk.admin.ch/ch/d/pore/va/vab_1_3_3_1.html)

However, the website has been redesigned:
https://www.bk.admin.ch/de/blanko-abstimmungstermine

The data is no longer stored statically on that page; instead, an iFrame from https://visualize.admin.ch/ is used. This means you can retrieve this data via Lindas.

-> Use LINDAS for getting parole dates