### PR TITLE
replace set-output

### DIFF
--- a/.github/workflows/update_abstimmungsparolen.yml
+++ b/.github/workflows/update_abstimmungsparolen.yml
@@ -44,9 +44,9 @@ jobs:
       run: |
         if git diff -w --no-ext-diff --quiet
         then
-          echo '::set-output name=changed::0'
+          echo "changed=0" >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=changed::1'
+          echo "changed=1" >> $GITHUB_OUTPUT
         fi
       id: changes
         

--- a/.github/workflows/update_mrz_patolu.yml
+++ b/.github/workflows/update_mrz_patolu.yml
@@ -41,9 +41,9 @@ jobs:
       run: |
         if git diff -w --no-ext-diff --quiet
         then
-          echo '::set-output name=changed::0'
+          echo "changed=0" >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=changed::1'
+          echo "changed=1" >> $GITHUB_OUTPUT
         fi
       id: changes
         

--- a/.github/workflows/update_sar_geschaeftsberichte.yml
+++ b/.github/workflows/update_sar_geschaeftsberichte.yml
@@ -48,11 +48,6 @@ jobs:
         python automation/xls_to_meta_xml.py -f automation/sar_geschaeftsberichte/OGD-Metadaten_Geschaeftsberichte.xlsx --outfile automation/sar_geschaeftsberichte/meta.xml --tag github
         python automation/update_metadata.py -d sar_geschaeftsberichte -f automation/sar_geschaeftsberichte/meta.xml
 
-    - name: Get current unix timestamp
-      if: always()
-      id: date
-      run: echo "::set-output name=ts::$(date +'%s')"
-      
     - name: Notify telegram failure
       if: ${{ failure()  || cancelled() }}
       uses: appleboy/telegram-action@master

--- a/.github/workflows/update_schulferien.yml
+++ b/.github/workflows/update_schulferien.yml
@@ -40,10 +40,10 @@ jobs:
         if [[ -z $(git status --porcelain) ]];
         then
           echo "Repo is clean"
-          echo '::set-output name=changed::0'
+          echo "changed=0" >> $GITHUB_OUTPUT
         else
           echo "Repo is dirty"
-          echo '::set-output name=changed::1'
+          echo "changed=1" >> $GITHUB_OUTPUT
         fi
       id: changes
         

--- a/.github/workflows/update_sonnenscheindauer.yml
+++ b/.github/workflows/update_sonnenscheindauer.yml
@@ -33,9 +33,9 @@ jobs:
       run: |
         if git diff -w --no-ext-diff --quiet
         then
-          echo '::set-output name=changed::0'
+          echo "changed=0" >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=changed::1'
+          echo "changed=1" >> $GITHUB_OUTPUT
         fi
       id: changes
         

--- a/automation/README.md
+++ b/automation/README.md
@@ -106,9 +106,9 @@ jobs:
       run: |
         if git diff -w --no-ext-diff --quiet
         then
-          echo '::set-output name=changed::0'
+          echo "changed=0" >> $GITHUB_OUTPUT
         else
-          echo '::set-output name=changed::1'
+          echo "changed=1" >> $GITHUB_OUTPUT
         fi
       id: changes
       
@@ -231,9 +231,9 @@ Einige Workflow pflegen die Daten direkt im Repository, wenn also eine Datei ver
   run: |
     if git diff -w --no-ext-diff --quiet
     then
-      echo '::set-output name=changed::0'
+      echo "changed=0" >> $GITHUB_OUTPUT
     else
-      echo '::set-output name=changed::1'
+      echo "changed=1" >> $GITHUB_OUTPUT
     fi
   id: changes
       


### PR DESCRIPTION
The `set-output` in Github Actions is deprecated and will be removed. This is why we recieve warnings. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

-> Replace the command to silence warnings

