### PR TITLE
Add metadata to Download stats

### DIFF
--- a/.github/workflows/update_download_statistics.yml
+++ b/.github/workflows/update_download_statistics.yml
@@ -29,7 +29,7 @@ jobs:
     - name: "Set up Python"
       uses: actions/setup-python@v6
       with:
-        python-version: 3.12
+        python-version: 3.14
 
     - name: Install requirements
       run: uv pip install -r automation/automation-requirements.txt
@@ -53,7 +53,7 @@ jobs:
       run: rm gcp-key.json
 
     - name: Upload dropped rows as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: download-tracking-dropped
         path: ogd_katalog_downloads_*_dropped.parquet

--- a/.github/workflows/update_download_statistics.yml
+++ b/.github/workflows/update_download_statistics.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   update_data_py:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     environment: production
 
     steps:
@@ -52,6 +52,13 @@ jobs:
     - name: Clean up
       run: rm gcp-key.json
 
+    - name: Upload dropped rows as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: download-tracking-dropped
+        path: ogd_katalog_downloads_*_dropped.parquet
+        retention-days: 30
+
     - name: Upload file to CKAN
       env:
         CKAN_BASE_URL: ${{ secrets.CKAN_BASE_URL }}
@@ -71,4 +78,4 @@ jobs:
         token: ${{ secrets.TELEGRAM_TOKEN }}
         format: markdown
         message: |
-          🔴 [VBZ Frequenzen Job Failed](https://github.com/opendatazurich/opendatazurich.github.io/actions/runs/${{ github.run_id }}?check_suite_focus=true)
+          🔴 [Update Download Statistics Job Failed](https://github.com/opendatazurich/opendatazurich.github.io/actions/runs/${{ github.run_id }}?check_suite_focus=true)

--- a/automation/download_statistics/README.md
+++ b/automation/download_statistics/README.md
@@ -7,6 +7,16 @@ Downloadstatistiken
 | **Workflow:**       | [`update_download_statistics.yml`](https://github.com/opendatazurich/opendatazurich.github.io/blob/master/.github/workflows/update_download_statistics.yml)  |
 | **Quelle:**         | Auswertung von Datopian. Zur Verfügung gestellt über Google Cloud Storage      |
 | **Datensatz INT:**  |                        |
-| **Datensatz PROD:** | [Downloads from OGD Katalog (pirvater Datensatz)](https://ckan-prod.zurich.datopian.com/dataset/prd_ssz_ogd_katalog_downloads) |
+| **Datensatz PROD:** | [Downloads from OGD Katalog (privater Datensatz)](https://ckan-prod.zurich.datopian.com/dataset/prd_ssz_ogd_katalog_downloads) |
 
-Datopian wertet die Logdateien von CKAN aus um festzustellen, welche Ressourcen heruntergeladen wurden. In Zukunft ist geplant, dass diese Daten als Open Data veröffentlicht werden. Dies ist ein vorläufiger Workflow, der sicherstellen soll, dass in der Zwischenzeit keine Daten verloren gehen.
+Datopian wertet die Logdateien von CKAN aus um festzustellen, welche Ressourcen heruntergeladen wurden. Datopian stellt über einen Google Cloud Bucket täglich eine neue Datei mit den Downloaddaten vom vorherigen Tag zur Verfügung. Alternativ kann man auch alle Daten der vergangenen Tage verwenden. Dies wird in Github Actions über die Option `USE_ROLLING_1_MONTH` gesteuert.
+
+Im Datensatz enthalten sind unter anderem die Spalten ``dataset_name``, ``resource_id`` und ``resource_name``. Diese sind aber nicht immer befüllt. Um die Datenqualität zu verbessern werden diese Spalten, wenn möglich mit Metadaten von CKAN aufgefüllt. Ist zum Beispiel nur die `resource_id` vorhanden, kann man mit Hilfe der CKAN-Metadaten `dataset_name` und `resource_name` herausfinden. Die benötigten Funktionen dafür befinden sich im Skript [`add_metadata.py`](add_metadata.py). Mit diesem Skript wurden auch die vorhandenen historischen Daten einmalig erweitert. Das passierte am 07.07.2026 zuletzt. Dabei muss man beachten, dass man von den CKAN Metadaten immer nur den aktuellen Stand hat. Wurde zum Beispiel im Jahr davor eine Ressource heruntergeladen, deren Ressourcen ID nicht mehr existiert, können dazu später auch keine Metadaten mehr gefunden werden.
+
+Es werden nicht alle Rohdaten übernommen, sondern es wird gefiltert nach diesem Muster: `dataset_name vohanden UND (resource_name vorhanden ODER resource_id vorhanden)`. Diejenigen Datensätze, die entfernt wurden, werden zeitlich begrenzt als artifact gespeichert.
+
+> **In Zukunft ist geplant, dass diese Daten als Open Data veröffentlicht werden. Dies ist ein vorläufiger Workflow, der sicherstellen soll, dass in der Zwischenzeit keine Daten verloren gehen.**
+
+**To do:**
+- [ ] Metadaten beschreiben
+- [ ] Datensatz veröffentlichen

--- a/automation/download_statistics/add_metadata.py
+++ b/automation/download_statistics/add_metadata.py
@@ -1,0 +1,431 @@
+
+# Add Metadata
+# 
+# Datopian liefert eine Tabelle mit Aufrufen aus ihren logs. Diese enthalten diverse Metadaten. 
+# Sie sind aber nicht vollständig. Deswegen sollen fehlende Metadaten ergänzt werden mit Informationen, die in den Metadaten von CKAN vorhanden sind.
+# 
+# Ziel ist, dass vor allem die Spalten `dataset_name` und `resource_name` möglichst immer befüllt sind.
+# 
+# Einschränkungen:
+# - Die Metadaten von CKAN enthalten nur den aktuellen Stand. Werden z.B. Ressourcen gelöscht und ersetzt können vielleicht keine Metadaten mehr dazu gefunden werden.
+# - Die Logs enthalten auch ungültige Anfragen, z.B. für Datensätze, die es nicht gibt, oder mit vertippern. Hier können keine Metadaten zugeordnet werden
+# 
+# Fehlende Metadaten bleiben erhalten, werden aber mit "UNKNOWN" gekennzeichnet.
+
+
+import os
+import io
+import logging
+import json
+
+from dotenv import load_dotenv
+from ckanapi import RemoteCKAN
+
+import pandas as pd
+import requests
+
+
+# setup logger
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+
+logger = logging.getLogger(__name__)
+
+
+
+# functions
+
+def get_ckan_metadata(ckan_url):
+    """
+    Get metadata from CKAN as JSON and convert to pandas dataframe.
+    
+    :param ckan_url: url for ckan metadata json
+    :return: df with metadata
+    :rtype: pd.DataFrame
+    """
+    logger.info(f"Getting CKAN metadata from {ckan_url}")
+    r = requests.get(ckan_url)
+    ckan = pd.DataFrame(json.loads(r.content)['result'])
+
+    return ckan
+
+
+
+# Funktion um Metadaten von Dataset-Ebene auf Ressourcen-Ebene zu explodieren.
+def dataset_to_resource(all_packages, prefix_resource_cols, resource_cols_to_keep):
+    """
+    Takes pandas df with all datasets (one row for each dataset).
+    Column "resources" must contain json info for each resource like:
+    [{'cache_last_updated': None, 'cache_url': None},...]
+    Json fields in resource get a prefix: prefix_resource_cols
+    This function explodes the df, so that each row in the output represents one resource.
+    """
+    # explode every resource in one row
+    all_packages_exploded = all_packages.explode('resources')
+    # json to columns and only keep the selected
+    resource_cols = pd.json_normalize(all_packages_exploded['resources'])[resource_cols_to_keep]
+    # add prefix, to avoid already existing columns
+    resource_cols = resource_cols.add_prefix(prefix_resource_cols)
+    # merge data from package/dataset
+    merged = resource_cols.merge(all_packages, how='left', left_on=prefix_resource_cols+"package_id",right_on='id')
+
+    # reset index, because later functions will need unique indices
+    merged = merged.reset_index(drop=True)
+
+    merged = merged.drop(columns=['resources'])
+
+    return merged
+
+
+
+def get_historical_data(year, dataset_name, base_url, api_key):
+    """
+    Download parquet with historical data from OGD catalogue. Checks if there is a ressource for the current year.
+        Needs
+        - ckan connection
+        - year
+        - dataset_name
+    return pandas df
+    """
+    ckan = RemoteCKAN(base_url, apikey=api_key)
+    dataset = ckan.action.package_show(id=dataset_name)
+    resources = dataset["resources"]
+    # check, if we already have a parquet file for the current year
+    for resource in resources:
+        if f"{year}.parquet" in resource["filename"]:
+            resource_id = resource["id"]
+
+    download_url = f"{base_url}/dataset/{dataset_name}/resource/{resource_id}/download"
+    logger.info(f"Download URL: {download_url}")
+
+    # Versuche Datei herunterzuladen
+    headers = {"Authorization": api_key}
+    response = requests.get(download_url, headers=headers)
+
+    if response.status_code == 200:
+        file_like = io.BytesIO(response.content)
+        df = pd.read_parquet(file_like)
+        logger.info("Datei geladen")
+    else:
+        logger.error(f"Fehler beim Download: {response.status_code} - {response.text}")
+
+
+    return df
+
+
+
+def extract_resource_id_from_datastore_sql(datopian):
+    """
+    Sonderbehandlung datastore_search_sql
+    Hier kann man der URL ein SQL mitgeben. Dabei muss nach dem `FROM` die resource_id kommen. 
+    In den meisten Fällen wird die ID schon korrekt von Datopian extrahiert. 
+    Es gibt aber ein paar Spezialfälle, die wir hier noch abholen.
+
+
+    pattern = r'(?i)from(?:%20|[+])%22([0-9a-f-]{36})%22'
+    - (?i) → case-insensitive (FROM, from, From, ...)
+    - from → sucht das FROM-Keyword
+    - (?:%20|[+]) → Leerzeichen als %20 oder +
+    - %22 → URL-codiertes Anführungszeichen (")
+    - ([0-9a-f-]{36}) → UUID wird als Capture Group extrahiert
+    - %22 → schliessendes Anführungszeichen
+    """
+
+    logger.info("Extrahiere resource_id von datastore_search_sql")
+
+    pattern = r"(?i)from(?:%20|[+])%22([0-9a-f-]{36})%22"
+
+    # Neue Spalte mit extrahierter ID
+    datopian['extracted_resource_id'] = datopian['url'].str.extract(pattern)
+
+
+    number_resource_id_new = datopian[
+        (datopian['extracted_resource_id'].notna()) & 
+        (datopian["resource_id"].isna())
+    ].shape[0]
+    logger.info(f"Anzahl Datensätze wo vorher kein resource_id, jetzt aber schon: {number_resource_id_new}")
+
+
+    # auffüllen der Spalte, falls leer
+    datopian['resource_id'] = datopian['resource_id'].combine_first(datopian['extracted_resource_id'])
+
+    return datopian
+
+
+def matching_via_resource_id(datopian: pd.DataFrame, ckan_exploded: pd.DataFrame):
+    """
+    Matching über resource_id
+    
+    Idee: Teilweise ist die Resource_id schon vorhanden und kann deswegen mit der resource_id von den CKAN Metadaten verknüpft werden. 
+    Dadurch können wir diese Fälle nutzen um später, evtl. fehlende andere Metadaten (dataset_name, resource_name) hinzuzufügen.
+
+    :return: merge_resource_id
+    """
+
+    logger.info("Join Metadaten über resource_id")
+
+    # join über resource_id, evtl. doppelte Spalten werden mit Suffix gekennzeichnet
+    merge_resource_id = datopian.merge(
+        ckan_exploded, 
+        how='left', 
+        left_on='resource_id', 
+        right_on='ckan_resource_id', 
+        suffixes=('', '_over_resource_id')
+    )
+
+    # Quick Check für Fehler bei Merge (kein output, wenn alles ok)
+    if merge_resource_id.shape[0] != datopian.shape[0]:
+        logger.info("Anzahl hat sich durch merge verändert!")
+        logger.info(f"Original {datopian.shape[0]}")
+        logger.info(f"Neu {merge_resource_id.shape[0]}")
+
+
+    number_dataset_name_new = merge_resource_id[
+        (merge_resource_id["dataset_name"].isna()) &
+        (merge_resource_id["name"].notna())
+    ].shape[0]
+    logger.info(f"Anzahl Datensätze wo vorher kein dataset_name, jetzt aber schon: {number_dataset_name_new}")
+
+    return merge_resource_id
+
+
+def matching_via_resource_name(merge_resource_id: pd.DataFrame, ckan_exploded: pd.DataFrame, datopian: pd.DataFrame):
+    """
+    Matching über resource_name 
+    Teilweise ist ein resource_name vorhanden, aber kein dataset_name. Deswegen matchen wir über den resource_name und können dann hoffentlich damit einie dataset_name auffüllen.
+    
+    Probleme: 
+    - Einige resource_names enthalten Artefakte am Ende des Dateinamens. Diese werden weggespalten: `ugz_ogd_meteo_h1_2020.csv%5C`
+    - Resource names sind nicht unique. Deswegen kann nur mit denen gematched werden, die unique sind.
+
+    :return: merge_resource_name
+    """
+
+    logger.info("Join Metadaten über resource_name")
+
+    # entferne "%5C" String am Ende
+    merge_resource_id["resource_name_stripped"] = merge_resource_id["resource_name"].str.rstrip("%5C")
+
+
+    # finde eindeutige resource names
+    value_counts = ckan_exploded['ckan_resource_name'].value_counts() 
+    # Filtere auf Werte, die nur einmal vorkommen
+    unique_names = value_counts[value_counts == 1].index
+    ckan_exploded_unique_names = ckan_exploded[ckan_exploded['ckan_resource_name'].isin(unique_names)]
+
+
+    # join über (bereinigten) resource_name, evtl. doppelte Spalten werden mit Suffix gekennzeichnet
+    merge_resource_name = merge_resource_id.merge(
+        ckan_exploded_unique_names, 
+        how='left', 
+        left_on='resource_name_stripped', 
+        right_on='ckan_resource_name', 
+        suffixes=('', '_over_resource_name'))
+
+
+    # Quick Check für Fehler bei Merge (kein output, wenn alles ok)
+    if merge_resource_name.shape[0] != datopian.shape[0]:
+        logger.info("Anzahl hat sich durch merge verändert!")
+        logger.info(f"Original {datopian.shape[0]}")
+        logger.info(f"Neu {merge_resource_name.shape[0]}")
+
+    number_dataset_name_over_resource_name_new = merge_resource_name[
+        (merge_resource_name["dataset_name"].isna()) &
+        (merge_resource_name["name_over_resource_name"].notna())
+    ].shape[0]
+    logger.info(f"Anzahl Datensätze wo vorher kein dataset_name, jetzt aber schon: {number_dataset_name_over_resource_name_new}")
+
+    return merge_resource_name
+
+def populate_dataset_name(merge_resource_name: pd.DataFrame):
+    """
+    Auffüllen von dataset_name, nach fester Hierarchie.
+
+    :return: merge_resource_name
+    """
+    logger.info("Auffüllen Spalte dataset_name")
+
+    merge_resource_name['coalesce_dataset_name'] = (
+        # nimm zuerst vorhandenen dataset name
+        merge_resource_name['dataset_name']
+        # falls, leer nimm Eintrag von matching über resource_id
+        .combine_first(merge_resource_name['name'])
+        # falls, leer nimm Eintrag von matching über resource_name
+        .combine_first(merge_resource_name['name_over_resource_name'])
+    )
+
+    # ersetze alte Spalte durch neue erweiterte Spalte
+    merge_resource_name['dataset_name'] = merge_resource_name['coalesce_dataset_name']
+
+    return merge_resource_name
+
+
+def populate_resource_name(merge_resource_name: pd.DataFrame):
+    """
+    Auffüllen von resource_name in neuer Spalte, nach fester Hierarchie.
+
+    :return: merge_resource_name
+    """
+    logger.info("Auffüllen Spalte resource_name")
+
+    merge_resource_name['coalesce_resource_name'] = (
+        # nimm zuerst vorhandenen resource name
+        merge_resource_name['resource_name']
+        # falls, leer nimm Eintrag von matching über resource_id
+        .combine_first(merge_resource_name['ckan_resource_name'])
+        # falls, leer nimm Eintrag von matching über resource_name
+        .combine_first(merge_resource_name['ckan_resource_name_over_resource_name'])
+    )
+
+    # ersetze alte Spalte durch neue erweiterte Spalte
+    merge_resource_name['resource_name'] = merge_resource_name['coalesce_resource_name']
+
+    return merge_resource_name
+
+def populate_resource_id(merge_resource_name: pd.DataFrame):
+    """
+    Auffüllen von Resource_id
+
+    :return: merge_resource_name
+    """
+    logger.info("Auffüllen Spalte resource_id")
+
+    merge_resource_name['coalesce_resource_id'] = (
+        # nimm zuerst vorhandenen resource id
+        merge_resource_name['resource_id']
+        # falls, leer nimm Eintrag von matching über resource_id
+        .combine_first(merge_resource_name['ckan_resource_id'])
+        # falls, leer nimm Eintrag von matching über resource_name
+        .combine_first(merge_resource_name['ckan_resource_id_over_resource_name'])
+    )
+
+
+    # ersetze alte Spalte durch neue erweiterte Spalte
+    merge_resource_name['resource_id'] = merge_resource_name['coalesce_resource_id']
+
+    return merge_resource_name
+
+
+def stats_before_after(before: pd.DataFrame, after: pd.DataFrame):
+    """
+    Statistiken für Vorher-Nachher-Vergleich
+    
+    :param before: dataset before adding metadata
+    :type before: pd.DataFrame
+    :param after: dataset after adding metadata
+    :type after: pd.DataFrame
+    """
+
+    # Wie viele fehlende Fälle haben wir für die relevanten Spalten?
+    missing_before = before[['dataset_name','resource_name','resource_id']].isna().sum()
+
+    # Vergleich vorher-nachher
+    missing_after = after[['dataset_name','resource_name','resource_id']].isna().sum()
+
+    combine_for_plot = pd.concat([missing_before, missing_after], axis=1).rename(columns={0: "missing_before", 1:"missing_after"})
+    logger.info(f"Anzahl Datensätze in Originaldatei: {before.shape[0]}")
+    logger.info(f"Anzahl Datensätze nachher: {after.shape[0]}")
+    logger.info(f"Vergleich Vorher-Nachher:\n{combine_for_plot}")
+
+def filter_data(merge_resource_name: pd.DataFrame):
+    """
+    Filter dataset (rows and columns) to final shape
+    
+    :param merge_resource_name: unfiltered dataset
+    :type merge_resource_name: pd.DataFrame
+    """
+
+    logger.info("Filtere Datensatz")
+
+    # Datensätze, die behalten werden. Übernommen werden nur, wenn: 
+    # dataset_name vohanden UND (resource_name vorhanden ODER resource_id vorhanden)
+    to_keep = merge_resource_name[
+        (merge_resource_name["dataset_name"].notna()) &
+        ((merge_resource_name["resource_name"].notna()) | (merge_resource_name["resource_id"].notna()))
+    ]
+    logger.info(f"Anzahl valide Datensätze: {to_keep.shape[0]}")
+
+    # Datensätze, die verloren gehen:
+    to_drop = merge_resource_name.drop(index=to_keep.index)
+    logger.info(f"Anzahl Datensätze, die nicht übernommen werden (weil dataset_name, resource_name und resource_id unbekannt): {to_drop.shape[0]}")
+
+    return (to_keep, to_drop)
+
+
+
+def add_metadata(datopian: pd.DataFrame):
+    """
+    Main function. Adding metadata from ckan to recieved dataframe.
+
+    
+    :param datopian: df with downloads stats. Needs columns `dataset_name`, `resource_name`, `resource_id`
+    :type datopian: pd.DataFrame
+
+    :return: merge_resource_name (df with updated metadata)
+    """
+
+
+    logger.info("Start adding metadata")
+
+    # # Hole CKAN Metadaten (auf dataset ebene)
+    ckan_url = 'https://data.stadt-zuerich.ch/api/3/action/current_package_list_with_resources?limit=1000'
+    ckan_meta = get_ckan_metadata(ckan_url)
+
+    # Funktion um Metadaten von Dataset-Ebene auf Ressourcen-Ebene zu explodieren.
+    ckan_exploded = dataset_to_resource(ckan_meta[['id','name','resources']], prefix_resource_cols='ckan_resource_', resource_cols_to_keep=['id','name','package_id'])
+
+
+    # Extrahiere resource_id von vom datastore_search_sql
+    datopian = extract_resource_id_from_datastore_sql(datopian)
+
+    # matching über resource_id
+    merge_resource_id = matching_via_resource_id(datopian, ckan_exploded)
+
+    # matching über resource_name
+    merge_resource_name = matching_via_resource_name(merge_resource_id, ckan_exploded, datopian)
+
+    # Auffüllen Spalte dataset_name
+    merge_resource_name = populate_dataset_name(merge_resource_name)
+
+    # Auffüllen Spalte resource_name
+    merge_resource_name = populate_resource_name(merge_resource_name)
+
+    # Auffüllen Spalte resource_id
+    merge_resource_name = populate_resource_id(merge_resource_name)
+
+    # statistiken zum vergleichen
+    stats_before_after(before=datopian, after=merge_resource_name)
+
+    # filtere daten
+    to_keep, to_drop = filter_data(merge_resource_name)
+
+    return to_keep, to_drop
+
+
+
+
+
+if __name__ == "__main__":
+
+    load_dotenv(override=True)
+
+    # # Lade Rohdaten für Downloads
+    # Die Funktion holt die Daten aus dem privaten Datensatz von CKAN.
+
+    BASE_URL = os.getenv('CKAN_BASE_URL')
+    API_KEY = os.getenv('CKAN_API_KEY')
+    YEAR = "2026"
+    datopian = get_historical_data(year=YEAR, dataset_name="prd_ssz_ogd_katalog_downloads", base_url=BASE_URL, api_key=API_KEY)
+
+
+    to_keep, to_drop = add_metadata(datopian)
+
+    # schreibe dateien
+    filename = f"ogd_katalog_downloads_{YEAR}"
+    COLS_TO_EXPORT = ["date","dataset_name","resource_name","resource_id","distinct_ips","user_agent","url","datastore_search_sql_query","hit_count"]
+    to_keep[COLS_TO_EXPORT].to_parquet(f"C:\\Temp\\prd_ssz_ogd_katalog_downloads\\{filename}_bereinigt.parquet")
+    to_drop[COLS_TO_EXPORT].to_parquet(f"C:\\Temp\\prd_ssz_ogd_katalog_downloads\\{filename}_dropped.parquet")
+
+    to_keep[COLS_TO_EXPORT].to_csv(f"C:\\Temp\\prd_ssz_ogd_katalog_downloads\\{filename}_bereinigt.csv")

--- a/automation/download_statistics/add_metadata.py
+++ b/automation/download_statistics/add_metadata.py
@@ -45,7 +45,7 @@ def get_ckan_metadata(ckan_url):
     :return: df with metadata
     :rtype: pd.DataFrame
     """
-    logger.info(f"Getting CKAN metadata from {ckan_url}")
+    logger.info(f"Hole CKAN-Metadaten von {ckan_url}")
     r = requests.get(ckan_url)
     ckan = pd.DataFrame(json.loads(r.content)['result'])
 
@@ -82,12 +82,15 @@ def dataset_to_resource(all_packages, prefix_resource_cols, resource_cols_to_kee
 
 def get_historical_data(year, dataset_name, base_url, api_key):
     """
-    Download parquet with historical data from OGD catalogue. Checks if there is a ressource for the current year.
-        Needs
-        - ckan connection
-        - year
-        - dataset_name
-    return pandas df
+    Download parquet with historical data from OGD catalogue.
+    Checks if there is a resource for the current year.
+
+    :param year: year to look for (e.g. "2026")
+    :param dataset_name: CKAN dataset name
+    :param base_url: CKAN base URL
+    :param api_key: CKAN API key
+    :return: dataframe with historical data
+    :rtype: pd.DataFrame
     """
     ckan = RemoteCKAN(base_url, apikey=api_key)
     dataset = ckan.action.package_show(id=dataset_name)
@@ -98,7 +101,7 @@ def get_historical_data(year, dataset_name, base_url, api_key):
             resource_id = resource["id"]
 
     download_url = f"{base_url}/dataset/{dataset_name}/resource/{resource_id}/download"
-    logger.info(f"Download URL: {download_url}")
+    logger.info(f"Download-URL: {download_url}")
 
     # Versuche Datei herunterzuladen
     headers = {"Authorization": api_key}
@@ -118,19 +121,22 @@ def get_historical_data(year, dataset_name, base_url, api_key):
 
 def extract_resource_id_from_datastore_sql(datopian):
     """
-    Sonderbehandlung datastore_search_sql
-    Hier kann man der URL ein SQL mitgeben. Dabei muss nach dem `FROM` die resource_id kommen. 
-    In den meisten Fällen wird die ID schon korrekt von Datopian extrahiert. 
-    Es gibt aber ein paar Spezialfälle, die wir hier noch abholen.
+    Extract resource_id from datastore_search_sql URLs.
+    In most cases Datopian already extracts the resource_id correctly.
+    This handles edge cases where the resource_id is embedded in a SQL query after FROM.
 
+    Pattern: r'(?i)from(?:%20|[+])%22([0-9a-f-]{36})%22'
+    - (?i)              → case-insensitive (FROM, from, From, ...)
+    - from              → matches the FROM keyword
+    - (?:%20|[+])       → space encoded as %20 or +
+    - %22               → URL-encoded double quote (")
+    - ([0-9a-f-]{36})   → UUID captured as a group
+    - %22               → closing double quote
 
-    pattern = r'(?i)from(?:%20|[+])%22([0-9a-f-]{36})%22'
-    - (?i) → case-insensitive (FROM, from, From, ...)
-    - from → sucht das FROM-Keyword
-    - (?:%20|[+]) → Leerzeichen als %20 oder +
-    - %22 → URL-codiertes Anführungszeichen (")
-    - ([0-9a-f-]{36}) → UUID wird als Capture Group extrahiert
-    - %22 → schliessendes Anführungszeichen
+    :param datopian: dataframe with download stats, must contain columns `url` and `resource_id`
+    :type datopian: pd.DataFrame
+    :return: dataframe with updated resource_id column
+    :rtype: pd.DataFrame
     """
 
     logger.info("Extrahiere resource_id von datastore_search_sql")
@@ -156,12 +162,15 @@ def extract_resource_id_from_datastore_sql(datopian):
 
 def matching_via_resource_id(datopian: pd.DataFrame, ckan_exploded: pd.DataFrame):
     """
-    Matching über resource_id
-    
-    Idee: Teilweise ist die Resource_id schon vorhanden und kann deswegen mit der resource_id von den CKAN Metadaten verknüpft werden. 
-    Dadurch können wir diese Fälle nutzen um später, evtl. fehlende andere Metadaten (dataset_name, resource_name) hinzuzufügen.
+    Join CKAN metadata via resource_id.
+    Where resource_id is already present, it is used to look up dataset_name and resource_name from CKAN.
 
-    :return: merge_resource_id
+    :param datopian: dataframe with download stats
+    :type datopian: pd.DataFrame
+    :param ckan_exploded: CKAN metadata at resource level
+    :type ckan_exploded: pd.DataFrame
+    :return: merged dataframe
+    :rtype: pd.DataFrame
     """
 
     logger.info("Join Metadaten über resource_id")
@@ -193,14 +202,22 @@ def matching_via_resource_id(datopian: pd.DataFrame, ckan_exploded: pd.DataFrame
 
 def matching_via_resource_name(merge_resource_id: pd.DataFrame, ckan_exploded: pd.DataFrame, datopian: pd.DataFrame):
     """
-    Matching über resource_name 
-    Teilweise ist ein resource_name vorhanden, aber kein dataset_name. Deswegen matchen wir über den resource_name und können dann hoffentlich damit einie dataset_name auffüllen.
-    
-    Probleme: 
-    - Einige resource_names enthalten Artefakte am Ende des Dateinamens. Diese werden weggespalten: `ugz_ogd_meteo_h1_2020.csv%5C`
-    - Resource names sind nicht unique. Deswegen kann nur mit denen gematched werden, die unique sind.
+    Join CKAN metadata via resource_name.
+    For rows where resource_name is present but dataset_name is missing,
+    matches on resource_name to fill in dataset_name.
 
-    :return: merge_resource_name
+    Caveats:
+    - Some resource_names contain trailing artefacts (e.g. `ugz_ogd_meteo_h1_2020.csv%5C`) which are stripped first.
+    - Only unique resource_names in CKAN are used for matching to avoid ambiguity.
+
+    :param merge_resource_id: dataframe after resource_id matching
+    :type merge_resource_id: pd.DataFrame
+    :param ckan_exploded: CKAN metadata at resource level
+    :type ckan_exploded: pd.DataFrame
+    :param datopian: original dataframe (used for row count validation)
+    :type datopian: pd.DataFrame
+    :return: merged dataframe
+    :rtype: pd.DataFrame
     """
 
     logger.info("Join Metadaten über resource_name")
@@ -241,9 +258,15 @@ def matching_via_resource_name(merge_resource_id: pd.DataFrame, ckan_exploded: p
 
 def populate_dataset_name(merge_resource_name: pd.DataFrame):
     """
-    Auffüllen von dataset_name, nach fester Hierarchie.
+    Fill dataset_name column using a fixed priority:
+    1. existing dataset_name
+    2. name from resource_id match
+    3. name from resource_name match
 
-    :return: merge_resource_name
+    :param merge_resource_name: dataframe after both matching steps
+    :type merge_resource_name: pd.DataFrame
+    :return: dataframe with updated dataset_name column
+    :rtype: pd.DataFrame
     """
     logger.info("Auffüllen Spalte dataset_name")
 
@@ -264,9 +287,15 @@ def populate_dataset_name(merge_resource_name: pd.DataFrame):
 
 def populate_resource_name(merge_resource_name: pd.DataFrame):
     """
-    Auffüllen von resource_name in neuer Spalte, nach fester Hierarchie.
+    Fill resource_name column using a fixed priority:
+    1. existing resource_name
+    2. name from resource_id match
+    3. name from resource_name match
 
-    :return: merge_resource_name
+    :param merge_resource_name: dataframe after both matching steps
+    :type merge_resource_name: pd.DataFrame
+    :return: dataframe with updated resource_name column
+    :rtype: pd.DataFrame
     """
     logger.info("Auffüllen Spalte resource_name")
 
@@ -286,9 +315,15 @@ def populate_resource_name(merge_resource_name: pd.DataFrame):
 
 def populate_resource_id(merge_resource_name: pd.DataFrame):
     """
-    Auffüllen von Resource_id
+    Fill resource_id column using a fixed priority:
+    1. existing resource_id
+    2. id from resource_id match
+    3. id from resource_name match
 
-    :return: merge_resource_name
+    :param merge_resource_name: dataframe after both matching steps
+    :type merge_resource_name: pd.DataFrame
+    :return: dataframe with updated resource_id column
+    :rtype: pd.DataFrame
     """
     logger.info("Auffüllen Spalte resource_id")
 
@@ -367,7 +402,7 @@ def add_metadata(datopian: pd.DataFrame):
     """
 
 
-    logger.info("Start adding metadata")
+    logger.info("Starte Metadaten-Ergänzung")
 
     # # Hole CKAN Metadaten (auf dataset ebene)
     ckan_url = 'https://data.stadt-zuerich.ch/api/3/action/current_package_list_with_resources?limit=1000'

--- a/automation/download_statistics/download_statistics.py
+++ b/automation/download_statistics/download_statistics.py
@@ -1,7 +1,7 @@
-# pip install google-cloud-storage
 import os
 import io
 import sys
+import logging
 import pandas as pd
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
@@ -9,7 +9,16 @@ from google.cloud import storage
 from ckanapi import RemoteCKAN, NotFound, NotAuthorized
 import requests
 
-#functions
+import add_metadata
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# functions
 
 def download_from_gcs(use_rolling_1_month_bool, bucket_name, download_folder=""):
     """
@@ -22,14 +31,14 @@ def download_from_gcs(use_rolling_1_month_bool, bucket_name, download_folder="")
     else:
         # get yesterdays date
         yesterday = (datetime.now() - timedelta(days=1)).strftime('%Y_%m_%d') # for daily triggering (override for manual date)
-        print("yesterday:", yesterday)
+        logger.info(f"Yesterday: {yesterday}")
         source_blob_name = f"download_tracking_{yesterday}.csv"
 
     # The path to which the file should be downloaded
     destination_file_name = os.path.join(download_folder, source_blob_name)
 
     storage_client = storage.Client()
-    print("Get bucket:", bucket_name)
+    logger.info(f"Get bucket: {bucket_name}")
     bucket = storage_client.bucket(bucket_name)
 
 
@@ -38,7 +47,7 @@ def download_from_gcs(use_rolling_1_month_bool, bucket_name, download_folder="")
     # any content from Google Cloud Storage. As we don't need additional data,
     # using `Bucket.blob` is preferred here.
     blob = bucket.blob(source_blob_name)
-    print("Downloading", source_blob_name,"to",destination_file_name)
+    logger.info(f"Downloading {source_blob_name} to {destination_file_name}")
     blob.download_to_filename(destination_file_name)
 
     return destination_file_name
@@ -53,23 +62,18 @@ def load_current_file(filename):
 
 
 
-def add_missing_metadata():
-    """
-    Add metadata from CKAN-API in case it is missing
-    """
-    pass
-
-
-
-def get_historical_data(ckan, year, dataset_name):
+def get_historical_data(year, dataset_name, base_url, api_key):
     """
     Download parquet with historical data from OGD catalogue. Checks if there is a ressource for the current year.
         Needs 
-        - ckan connection
         - year
         - dataset_name
+        - base_url
+        - api_key
     return pandas df
     """
+    ckan = RemoteCKAN(base_url, apikey=api_key)
+
     dataset = ckan.action.package_show(id=dataset_name)
     resources = dataset["resources"]
     # check, if we already have a parquet file for the current year
@@ -78,31 +82,36 @@ def get_historical_data(ckan, year, dataset_name):
             resource_id = resource["id"]
             break
 
-    download_url = f"{BASE_URL}/dataset/{dataset_name}/resource/{resource_id}/download"
-    print("Download URL:", download_url)
+    download_url = f"{base_url}/dataset/{dataset_name}/resource/{resource_id}/download"
+    logger.info(f"Download URL: {download_url}")
 
     # Versuche Datei herunterzuladen
-    headers = {"Authorization": API_KEY}
+    headers = {"Authorization": api_key}
     response = requests.get(download_url, headers=headers)
 
     if response.status_code == 200:
         file_like = io.BytesIO(response.content)
         df = pd.read_parquet(file_like)
-        print("Datei geladen")
+        logger.info("Datei geladen")
     else:
-        print(f"Fehler beim Download: {response.status_code} - {response.text}")
+        logger.error(f"Fehler beim Download: {response.status_code} - {response.text}")
 
 
     return df
 
-def concat_historical_and_current_data(df_all, df_new, year):
+def concat_historical_and_current_data(df_all, df_new, year, cols_to_keep):
     """
     Check if current data is already in historical data (and delete if so).
     Add current data to historical data
     """
+
+    # select columns
+    df_all = df_all[cols_to_keep]
+    df_new = df_new[cols_to_keep]
+
     # Hole die eindeutigen Datumswerte aus df
     dates_to_remove = df_new['date'].unique()
-    print("dropping dates from existing data, if present:", dates_to_remove)
+    logger.info(f"Dropping dates from existing data, if present: {dates_to_remove}")
 
     # Entferne die Zeilen aus df_all, deren 'date' in dates_to_remove enthalten ist
     df_all_filtered = df_all[~df_all['date'].isin(dates_to_remove)]
@@ -117,56 +126,67 @@ def concat_historical_and_current_data(df_all, df_new, year):
     # sort
     df_compl = df_compl.sort_values(by=list(df_compl))
 
-    print("New df has dates from:", df_compl['date'].min(), " to ", df_compl['date'].max())
+    logger.info(f"New df has dates from: {df_compl['date'].min()} to {df_compl['date'].max()}")
 
     return df_compl
 
-def save_updated_data_to_file(df, upload_filename, year):
+def save_updated_data_to_file(df, upload_filename, year, dropped):
     """
     Save to CSV and parquet
     """
     upload_filename_year = upload_filename + "_" + year
-    print("write parquet and csv to: ", upload_filename)
+    logger.info(f"Write parquet and csv to: {upload_filename_year}")
     df.to_parquet(f"{upload_filename_year}.parquet")
     df.to_csv(f"{upload_filename_year}.csv", index=False)
+    # save this as artifact for debugging
+    dropped.to_parquet(f"{upload_filename_year}_dropped.parquet")
+
+if __name__ == "__main__":
+
+    COLS_TO_EXPORT = ["date","dataset_name","resource_name","resource_id","distinct_ips","user_agent","url","datastore_search_sql_query","hit_count"]
+
+    # arguments
+    year = sys.argv[1]
+    logger.info(f"Year: {year}")
+
+    # only for local testing
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "C:\\Users\\sszgua\\Python\\jupyter\\ogd\\webstatistiken\\google-download-tracking-sa.json" #"ogd/webstatistiken/google-download-tracking-sa.json"
 
 
+    load_dotenv(override=True)
+    # for distinction: use file from yesterday, oder complete last month
+    # needs an input for the github workflow (default false)
 
-# arguments
-year = sys.argv[1]
-print("year", year)
+    USE_ROLLING_1_MONTH = os.getenv("USE_ROLLING_1_MONTH")
+    logger.info(f"USE_ROLLING_1_MONTH: {USE_ROLLING_1_MONTH}")
+    # convert string to bool
+    use_rolling_1_month_bool = bool(USE_ROLLING_1_MONTH.lower() == "true")
 
-# only for local testing
-# os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "ogd/webstatistiken/google-download-tracking-sa.json"
+    # bucket name from google cloud
+    bucket_name = "ssz-download-tracking"
 
-
-load_dotenv(override=True)
-# for distinction: use file from yesterday, oder complete last month
-# needs an input for the github workflow (default false)
-
-USE_ROLLING_1_MONTH = os.getenv("USE_ROLLING_1_MONTH")
-print("USE_ROLLING_1_MONTH:", USE_ROLLING_1_MONTH)
-# convert string to bool
-use_rolling_1_month_bool = bool(USE_ROLLING_1_MONTH.lower() == "true")
-
-# bucket name from google cloud
-bucket_name = "ssz-download-tracking"
-
-#connect to ckan
-BASE_URL = os.getenv('CKAN_BASE_URL')
-API_KEY = os.getenv('CKAN_API_KEY')
-ckan = RemoteCKAN(BASE_URL, apikey=API_KEY)
-df_all = get_historical_data(ckan, year=year, dataset_name = "prd_ssz_ogd_katalog_downloads")
-destination_file_name = download_from_gcs(use_rolling_1_month_bool, bucket_name)
-df_new = load_current_file(destination_file_name)
-print(df_new)
+    #connect to ckan
+    BASE_URL = os.getenv('CKAN_BASE_URL')
+    API_KEY = os.getenv('CKAN_API_KEY')
+    df_all = get_historical_data(year=year, dataset_name = "prd_ssz_ogd_katalog_downloads", base_url=BASE_URL, api_key=API_KEY)
+    destination_file_name = download_from_gcs(use_rolling_1_month_bool, bucket_name)
+    df_new = load_current_file(destination_file_name)
+    logger.info(f"\n{df_new}")
 
 
+    # add additional metadata here
+    to_keep, to_drop = add_metadata.add_metadata(df_new)
 
+    df_compl = concat_historical_and_current_data(
+        df_all, 
+        to_keep, 
+        year,
+        COLS_TO_EXPORT
+    )
 
-# add additional metadata here
-# ...
-
-df_compl = concat_historical_and_current_data(df_all, df_new, year)
-
-save_updated_data_to_file(df_compl, upload_filename='ogd_katalog_downloads', year=year)
+    save_updated_data_to_file(
+        df_compl, 
+        upload_filename='ogd_katalog_downloads', 
+        year=year,
+        dropped=to_drop,
+    )

--- a/automation/download_statistics/download_statistics.py
+++ b/automation/download_statistics/download_statistics.py
@@ -22,8 +22,14 @@ logger = logging.getLogger(__name__)
 
 def download_from_gcs(use_rolling_1_month_bool, bucket_name, download_folder=""):
     """
-    Decide if we need the file from yesterday or from the complete last month and download it from google cloud storage.
-    Return the path to the downloaded file
+    Download file from Google Cloud Storage.
+    Decides based on use_rolling_1_month_bool whether to fetch yesterday's file or the rolling 1-month file.
+
+    :param use_rolling_1_month_bool: if True, download rolling 1-month file; otherwise download yesterday's file
+    :param bucket_name: name of the GCS bucket
+    :param download_folder: local folder to download the file to
+    :return: path to the downloaded file
+    :rtype: str
     """
 
     if use_rolling_1_month_bool:
@@ -31,14 +37,14 @@ def download_from_gcs(use_rolling_1_month_bool, bucket_name, download_folder="")
     else:
         # get yesterdays date
         yesterday = (datetime.now() - timedelta(days=1)).strftime('%Y_%m_%d') # for daily triggering (override for manual date)
-        logger.info(f"Yesterday: {yesterday}")
+        logger.info(f"Gestriges Datum: {yesterday}")
         source_blob_name = f"download_tracking_{yesterday}.csv"
 
     # The path to which the file should be downloaded
     destination_file_name = os.path.join(download_folder, source_blob_name)
 
     storage_client = storage.Client()
-    logger.info(f"Get bucket: {bucket_name}")
+    logger.info(f"Hole Bucket: {bucket_name}")
     bucket = storage_client.bucket(bucket_name)
 
 
@@ -47,7 +53,7 @@ def download_from_gcs(use_rolling_1_month_bool, bucket_name, download_folder="")
     # any content from Google Cloud Storage. As we don't need additional data,
     # using `Bucket.blob` is preferred here.
     blob = bucket.blob(source_blob_name)
-    logger.info(f"Downloading {source_blob_name} to {destination_file_name}")
+    logger.info(f"Lade {source_blob_name} herunter nach {destination_file_name}")
     blob.download_to_filename(destination_file_name)
 
     return destination_file_name
@@ -55,7 +61,11 @@ def download_from_gcs(use_rolling_1_month_bool, bucket_name, download_folder="")
 
 def load_current_file(filename):
     """
-    Load the file that what downloaded into df
+    Load CSV file into a dataframe.
+
+    :param filename: path to the CSV file
+    :return: dataframe with parsed date column
+    :rtype: pd.DataFrame
     """
     df_new = pd.read_csv(filename, parse_dates=['date'])
     return df_new
@@ -64,13 +74,15 @@ def load_current_file(filename):
 
 def get_historical_data(year, dataset_name, base_url, api_key):
     """
-    Download parquet with historical data from OGD catalogue. Checks if there is a ressource for the current year.
-        Needs 
-        - year
-        - dataset_name
-        - base_url
-        - api_key
-    return pandas df
+    Download parquet with historical data from OGD catalogue.
+    Checks if there is a resource for the current year.
+
+    :param year: year to look for (e.g. "2026")
+    :param dataset_name: CKAN dataset name
+    :param base_url: CKAN base URL
+    :param api_key: CKAN API key
+    :return: dataframe with historical data
+    :rtype: pd.DataFrame
     """
     ckan = RemoteCKAN(base_url, apikey=api_key)
 
@@ -83,7 +95,7 @@ def get_historical_data(year, dataset_name, base_url, api_key):
             break
 
     download_url = f"{base_url}/dataset/{dataset_name}/resource/{resource_id}/download"
-    logger.info(f"Download URL: {download_url}")
+    logger.info(f"Download-URL: {download_url}")
 
     # Versuche Datei herunterzuladen
     headers = {"Authorization": api_key}
@@ -101,8 +113,15 @@ def get_historical_data(year, dataset_name, base_url, api_key):
 
 def concat_historical_and_current_data(df_all, df_new, year, cols_to_keep):
     """
-    Check if current data is already in historical data (and delete if so).
-    Add current data to historical data
+    Merge current data into historical data.
+    Removes any dates from the historical data that are also present in the new data to avoid duplicates.
+
+    :param df_all: historical data
+    :param df_new: new data to add
+    :param year: only keep data from this year onwards
+    :param cols_to_keep: list of columns to retain
+    :return: merged and deduplicated dataframe
+    :rtype: pd.DataFrame
     """
 
     # select columns
@@ -111,7 +130,7 @@ def concat_historical_and_current_data(df_all, df_new, year, cols_to_keep):
 
     # Hole die eindeutigen Datumswerte aus df
     dates_to_remove = df_new['date'].unique()
-    logger.info(f"Dropping dates from existing data, if present: {dates_to_remove}")
+    logger.info(f"Entferne folgende Daten aus bestehenden Daten (falls vorhanden): {dates_to_remove}")
 
     # Entferne die Zeilen aus df_all, deren 'date' in dates_to_remove enthalten ist
     df_all_filtered = df_all[~df_all['date'].isin(dates_to_remove)]
@@ -126,16 +145,22 @@ def concat_historical_and_current_data(df_all, df_new, year, cols_to_keep):
     # sort
     df_compl = df_compl.sort_values(by=list(df_compl))
 
-    logger.info(f"New df has dates from: {df_compl['date'].min()} to {df_compl['date'].max()}")
+    logger.info(f"Neuer Datensatz enthält Daten von {df_compl['date'].min()} bis {df_compl['date'].max()}")
 
     return df_compl
 
 def save_updated_data_to_file(df, upload_filename, year, dropped):
     """
-    Save to CSV and parquet
+    Save dataframe to CSV and parquet.
+    Also saves dropped rows as a parquet artifact for debugging.
+
+    :param df: main dataframe to save
+    :param upload_filename: base filename (year will be appended)
+    :param year: year suffix for the filename
+    :param dropped: rows that were dropped, saved as a separate parquet for debugging
     """
     upload_filename_year = upload_filename + "_" + year
-    logger.info(f"Write parquet and csv to: {upload_filename_year}")
+    logger.info(f"Schreibe Parquet und CSV nach: {upload_filename_year}")
     df.to_parquet(f"{upload_filename_year}.parquet")
     df.to_csv(f"{upload_filename_year}.csv", index=False)
     # save this as artifact for debugging
@@ -147,7 +172,7 @@ if __name__ == "__main__":
 
     # arguments
     year = sys.argv[1]
-    logger.info(f"Year: {year}")
+    logger.info(f"Jahr: {year}")
 
     # only for local testing
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "C:\\Users\\sszgua\\Python\\jupyter\\ogd\\webstatistiken\\google-download-tracking-sa.json" #"ogd/webstatistiken/google-download-tracking-sa.json"

--- a/automation/download_statistics/download_statistics.py
+++ b/automation/download_statistics/download_statistics.py
@@ -175,7 +175,7 @@ if __name__ == "__main__":
     logger.info(f"Jahr: {year}")
 
     # only for local testing
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "C:\\Users\\sszgua\\Python\\jupyter\\ogd\\webstatistiken\\google-download-tracking-sa.json" #"ogd/webstatistiken/google-download-tracking-sa.json"
+    # os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "ogd/webstatistiken/google-download-tracking-sa.json"
 
 
     load_dotenv(override=True)


### PR DESCRIPTION
The available download stats have information like dataset_name and resource_name. But in some cases they are missing. These changed fill in empty data in the columns `dataset_name`, `resource_id` and `resource_name`. This work when some othe metadata is provided. For example: When resource_id is provided you can use the CKAN metadata to find out the resource_name and dataset_name.

Note, that only the present metadata can be used. For historical data there might still be missing information, for example when it points to a download of a resource where the resource_id has changed.

Only rows that match these conditions are pretained:
dataset_name is present AND (resource_name is present OR resource_id is present)

All others get dropped. For debugging the dropped df is saved as an artifact.